### PR TITLE
Test with domino logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: node_js
-node_js:
-  - '4'
-before_script:
-  - export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# bel-create-element
+# belit
 
 Fork of a simple library for composable DOM elements using [tagged template strings](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals).
 

--- a/appendChild.js
+++ b/appendChild.js
@@ -1,4 +1,6 @@
-var document = typeof window !== 'undefined' ? window.document : require('min-document')
+var document = typeof window !== 'undefined'
+  ? window.document
+  : require('domino').createWindow().document
 
 var trailingNewlineRegex = /\n[\s]+$/
 var leadingNewlineRegex = /^\n[\s]+/

--- a/bel.d.ts
+++ b/bel.d.ts
@@ -1,4 +1,0 @@
-declare module "bel" {
-    export default function (strings: TemplateStringsArray, ...keys): HTMLElement;
-    export function createElement (tag: string, attributes: any, children: Array<any>): HTMLElement;
-}

--- a/bench/create-trees.js
+++ b/bench/create-trees.js
@@ -1,8 +1,8 @@
 var bench = require('./bench')
-var bel = require('../')
-var vdom = require('virtual-dom')
-var h = vdom.h
-var document = require('global/document')
+var belCreateElement = require('../')
+var hyperx = require('hyperx')
+
+var h = hyperx(belCreateElement, {comments: true})
 
 function raw (label, items) {
   var div = document.createElement('div')
@@ -22,32 +22,20 @@ function raw (label, items) {
 }
 
 function withBel (label, items) {
-  return bel`<div>
+  return h`<div>
     <h1>${label}</h1>
     <ul>
       ${items.map(function (item) {
-        return bel`<li>${item}</li>`
+        return h`<li>${item}</li>`
       })}
     </ul>
   </div>`
-}
-
-function withVDOM (label, items) {
-  return h('div', [
-    h('h1', label),
-    h('ul', items.map(function (item) {
-      return h('li', item)
-    }))
-  ])
 }
 
 console.log('Creating trees...')
 var data = ['grizzly', 'polar', 'brown']
 bench('raw', function () {
   raw('test', data)
-})
-bench('withVDOM', function () {
-  withVDOM('test', data)
 })
 bench('withBel', function () {
   withBel('test', data)

--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
-var document = typeof window !== 'undefined' ? window.document : require('min-document')
+var document = typeof window !== 'undefined'
+  ? window.document
+  : require('domino').createWindow().document
+
 var appendChild = require('./appendChild')
 
 var SVGNS = 'http://www.w3.org/2000/svg'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "bel-create-element",
-  "version": "2.0.2",
+  "name": "belit",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2868,12 +2868,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/monotonic-timestamp/-/monotonic-timestamp-0.0.8.tgz",
       "integrity": "sha1-Z5h9AqQcFfVotsCgWIWYndJAK6A=",
-      "dev": true
-    },
-    "morphdom": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/morphdom/-/morphdom-2.3.3.tgz",
-      "integrity": "sha512-z+/GEulEfhrSFPOJSum8o5lZNv63cAGBPeFHO2WgpGo636Ln67ZuVydp2q0iTaZIXdf5FDNP2ZY6uhtg+LjlsA==",
       "dev": true
     },
     "ms": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bel-create-element",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1052,16 +1052,16 @@
         "isarray": "1.0.0"
       }
     },
-    "dom-walk": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
-    },
     "domain-browser": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
       "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
       "dev": true
+    },
+    "domino": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/domino/-/domino-2.0.0.tgz",
+      "integrity": "sha512-BAJKFY+TeUC7bsKT0BWkJU1ksXYPbMRmmGiE958DXMoTEJRig5BSm5Uo8tK2oBxZwuzYFFRQ9hXZG32zNiY4fQ=="
     },
     "duplexer": {
       "version": "0.1.1",
@@ -2795,14 +2795,6 @@
       "dev": true,
       "requires": {
         "mime-db": "1.30.0"
-      }
-    },
-    "min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "requires": {
-        "dom-walk": "0.1.1"
       }
     },
     "minimalistic-assert": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/jrjurman/bel-create-element",
   "dependencies": {
-    "min-document": "^2.19.0"
+    "domino": "^2.0.0"
   },
   "devDependencies": {
     "browser-process-hrtime": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   },
   "keywords": [
     "bel",
+    "bel-create-element",
+    "belit",
     "virtual-dom",
     "element",
     "diffhtml",
@@ -35,7 +37,6 @@
     "electron": "^1.7.9",
     "hyperx": "^2.3.1",
     "is-electron": "^2.1.0",
-    "morphdom": "^2.3.3",
     "standard": "^10.0.3",
     "tape": "^4.8.0",
     "tape-run": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "bel-create-element",
-  "version": "2.0.2",
-  "description": "just the bits",
+  "name": "belit",
+  "version": "3.0.0",
+  "description": "A simple function for creating composable DOM elements using tagged template strings.",
   "main": "index.js",
   "scripts": {
     "start": "wzrd test/index.js:bundle.js",
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/jrjurman/bel-create-element"
+    "url": "git://github.com/jrjurman/belit"
   },
   "keywords": [
     "bel",

--- a/test/server.js
+++ b/test/server.js
@@ -10,7 +10,7 @@ test('server side render', function (t) {
   var element = h`<div class="testing">
     <h1>hello!</h1>
   </div>`
-  var result = element.toString()
+  var result = element.outerHTML
   t.ok(result.indexOf('<h1>hello!</h1>') !== -1, 'contains a child element')
   t.ok(result.indexOf('<div class="testing">') !== -1, 'attribute gets set')
   t.end()
@@ -22,7 +22,7 @@ test('passing another element to bel on server side render', function (t) {
   var element = h`<div class="testing">
     ${button}
   </div>`
-  var result = element.toString()
+  var result = element.outerHTML
   t.ok(result.indexOf('<button>click</button>') !== -1, 'button rendered correctly')
   t.end()
 })
@@ -32,6 +32,6 @@ test('style attribute', function (t) {
   var name = 'test'
   var result = h`<h1 style="color: red">Hey ${name.toUpperCase()}, <span style="color: blue">This</span> is a card!!!</h1>`
   var expected = '<h1 style="color: red">Hey TEST, <span style="color: blue">This</span> is a card!!!</h1>'
-  t.equal(result.toString(), expected)
+  t.equal(result.outerHTML, expected)
   t.end()
 })


### PR DESCRIPTION
# Belit (v3.0.0)

## Summary
This PR introduces `domino` as a dependency for `bel-create-element`, and removes `min-document`.

### Pros
- spec conforms to modern dom
- domino has active development
- we can stop checking if we're in the browser to do basic logic
- all existing tests pass -> functionality is 1-1

### Cons
- extremely heavy (6MB)

## Should we care about the size?
While domino as a dependency is 6MB, it should be noted that most of the library won't be used. Effective tree-shaking should remove a lot of unused code.

## Other changes
- removed files that are not being used 
- change name to `belit`
- fixed bench scripts
- bump to version 3.0.0