### PR TITLE
Events

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,11 +16,17 @@ const toObjectList = props => prop => ({key: prop, value: props[prop]})
 const normalizeClassName = prop => prop.key.toLowerCase() === 'classname' ? ({key: 'class', value: prop.value}) : prop
 const htmlForToFor = prop => prop.key === 'htmlFor' ? ({key: 'for', value: prop.value}) : prop
 
+const addEventToElement = (element, eventKey, eventValue) => {
+  element[eventKey] = eventValue
+  // add event to element list of events
+  element.events = element.events ? element.events.concat(eventKey) : [eventKey]
+}
+
 // handlers that can be filtered on
-// if something gets processed, we return false (using ![])
+// if something gets processed, we return false
 // otherwise, it returns true, indicating that this thing needs to be processed
-const handleOnAttrSetter = element => prop => prop.key.slice(0, 2) === 'on' ? ![element[prop.key] = prop.value] : true
-const handleNamespaceAttrSetter = (element, namespace) => prop => namespace ? ![element.setAttributeNS(null, prop.key, prop.value)] : true
+const handleOnAttrSetter = element => prop => prop.key.slice(0, 2) === 'on' ? addEventToElement(element, prop.key, prop.value) || false : true
+const handleNamespaceAttrSetter = (element, namespace) => prop => namespace ? element.setAttributeNS(null, prop.key, prop.value) || false : true
 const handleAttrSetter = element => prop => element.setAttribute(prop.key, prop.value)
 
 const belitCreateElement = (namespace) => (tag, props, children) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "belit",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "belit",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "A simple function for creating composable DOM elements using tagged template strings.",
   "main": "index.js",
   "scripts": {
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/jrjurman/belit"
+    "url": "git://github.com/Tram-One/belit"
   },
   "keywords": [
     "bel",
@@ -26,9 +26,9 @@
   "author": "Jesse Jurman <j.r.jurman@gmail.com> (http://jrjurman.com)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/jrjurman/bel-create-element/issues"
+    "url": "https://github.com/Tram-One/bel-create-element/issues"
   },
-  "homepage": "https://github.com/jrjurman/bel-create-element",
+  "homepage": "https://github.com/Tram-One/bel-create-element",
   "dependencies": {
     "domino": "^2.0.0"
   },

--- a/test/elements.js
+++ b/test/elements.js
@@ -90,6 +90,15 @@ test('for attribute is set correctly', function (t) {
   t.end()
 })
 
+test('events are added to element events property', function (t) {
+  t.plan(1)
+  var result = html`<div>
+    <input oninput="onInputFunction" onkeyup="onKeyUpFunction" />
+  </div>`
+  t.deepEqual(result.querySelector('input').events, ['oninput', 'onkeyup'])
+  t.end()
+})
+
 test('allow objects to be passed', function (t) {
   t.plan(1)
   var result = html`<div>


### PR DESCRIPTION
## Summary

This is the first of an org-wide change to support events dynamically in Tram-One. This branches from https://github.com/Tram-One/tram-one/issues/76

This change embeds a list of events into elements. They can then be accessed using the `.events` property. This gives Tram-One access to the list of events bound to an element, which is not natively available on the element.

## Tests

A test has been added to verify that events are attached to the element. All tests pass locally.