### PR TITLE
Namespace attrs

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,9 +25,8 @@ const addEventToElement = (element, eventKey, eventValue) => {
 // handlers that can be filtered on
 // if something gets processed, we return false
 // otherwise, it returns true, indicating that this thing needs to be processed
-const handleOnAttrSetter = element => prop => prop.key.slice(0, 2) === 'on' ? addEventToElement(element, prop.key, prop.value) : true
-const handleNamespaceAttrSetter = (element, namespace) => prop => namespace ? element.setAttributeNS(namespace, prop.key, prop.value) : true
-const handleAttrSetter = element => prop => element.setAttribute(prop.key, prop.value)
+const handleEventSetter = element => prop => prop.key.slice(0, 2) === 'on' ? addEventToElement(element, prop.key, prop.value) : true
+const handleAttrSetter = element => prop => element.setAttributeNS(null, prop.key, prop.value)
 
 const belitCreateElement = (namespace) => (tag, props, children) => {
   // if the tag is a comment
@@ -45,8 +44,7 @@ const belitCreateElement = (namespace) => (tag, props, children) => {
     .map(toObjectList(props))
     .map(normalizeClassName)
     .map(htmlForToFor)
-    .filter(handleOnAttrSetter(element))
-    .filter(handleNamespaceAttrSetter(element, namespace))
+    .filter(handleEventSetter(element))
     .filter(handleAttrSetter(element))
 
   appendChild(element, children)

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ const addEventToElement = (element, eventKey, eventValue) => {
 // if something gets processed, we return false
 // otherwise, it returns true, indicating that this thing needs to be processed
 const handleOnAttrSetter = element => prop => prop.key.slice(0, 2) === 'on' ? addEventToElement(element, prop.key, prop.value) : true
-const handleNamespaceAttrSetter = (element, namespace) => prop => namespace ? element.setAttributeNS(null, prop.key, prop.value) : true
+const handleNamespaceAttrSetter = (element, namespace) => prop => namespace ? element.setAttributeNS(namespace, prop.key, prop.value) : true
 const handleAttrSetter = element => prop => element.setAttribute(prop.key, prop.value)
 
 const belitCreateElement = (namespace) => (tag, props, children) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "belit",
-  "version": "4.2.0",
+  "version": "4.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "belit",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "belit",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "A simple function for creating composable DOM elements using tagged template strings.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "belit",
-  "version": "4.2.0",
+  "version": "4.1.2",
   "description": "A simple function for creating composable DOM elements using tagged template strings.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

This PR removes the handler for namespaced attributes. Since this handler was effectively the same as `handleAttrSetter`, we have removed the former.  Also renamed `handleOnAttrSetter` to `handleEventSetter`, to be more clear.