### PR TITLE
patch fix document set on global object v4.1.5

### DIFF
--- a/appendChild.js
+++ b/appendChild.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-negated-condition no-global-assign */
-document = typeof window !== 'undefined' ?
-  window.document :
-  require('domino').createWindow().document
+if (typeof document === 'undefined') {
+  document = require('domino').createWindow().document
+}
 
 const parseNodeAsString = node => (typeof node === 'number' ||
                                    typeof node === 'boolean' ||

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-negated-condition, no-return-assign no-global-assign */
-document = typeof document !== 'undefined' ? document : require('domino').createWindow().document
+if (typeof document === 'undefined') {
+  document = require('domino').createWindow().document
+}
 
 const appendChild = require('./appendChild')
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "belit",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "description": "A simple function for creating composable DOM elements using tagged template strings.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
Currently we get an error for the umd module of tram-one, this patch should fix the issue, and prevent attempts to set the document for the umd module.